### PR TITLE
Fix created_at param name

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'DBIx::Class';
 requires 'Dancer2' => 0.163000;
 requires 'Dancer2::Plugin::DBIC';
+requires 'Dancer2::Plugin::REST';
 requires 'DateTime';
 requires 'DateTime::TimeZone';
 requires 'Data::GUID';
@@ -29,3 +30,7 @@ requires 'URL::Encode::XS';
 requires 'CGI::Deurl::XS';
 requires 'HTTP::Parser::XS';
 requires 'Math::Random::ISAAC::XS';
+
+requires 'MooseX::Types::JSON';
+requires 'MooseX::Types::LoadableClass';
+requires 'MooseX::Types::Path::Class';

--- a/lib/PearlBee/Model/Schema/ResultSet/Post.pm
+++ b/lib/PearlBee/Model/Schema/ResultSet/Post.pm
@@ -24,7 +24,7 @@ sub can_create {
   my $user_id       = $params->{user_id};
   my $status        = $params->{status};
   my $cover         = $params->{cover};
-  my $dt            = $params->{dt};
+  my $dt            = $params->{created_date};
 
   my $post = $self->create({
       title        => $title,


### PR DESCRIPTION
This fixes #40. It was explicictly adding NULL because it tried to get
the timestamp from $params->{dt}, which was undef. It was supposed to be
$params->{created_at}.