### PR TITLE
Remove the `blog_path` setting

### DIFF
--- a/db_patches/create_tables.sql
+++ b/db_patches/create_tables.sql
@@ -105,7 +105,6 @@ CREATE TABLE IF NOT EXISTS `comment` (
 CREATE TABLE IF NOT EXISTS `settings` (
   `timezone` varchar(255) NOT NULL,
   `social_media` tinyint(1) NOT NULL DEFAULT '1',
-  `blog_path` varchar(255) NOT NULL DEFAULT '/',
   `theme_folder` varchar(255) NOT NULL,
   `blog_name` varchar(255) NOT NULL,
   `multiuser` tinyint(1) NOT NULL DEFAULT '0',

--- a/db_patches/set_up_new_db.sql
+++ b/db_patches/set_up_new_db.sql
@@ -144,7 +144,6 @@ DROP TABLE IF EXISTS `settings`;
 CREATE TABLE `settings` (
   `timezone` varchar(255) NOT NULL,
   `social_media` tinyint(1) NOT NULL DEFAULT '1',
-  `blog_path` varchar(255) NOT NULL DEFAULT '/',
   `theme_folder` varchar(255) NOT NULL,
   `blog_name` varchar(255) NOT NULL,
   `multiuser` tinyint(1) NOT NULL DEFAULT '0',

--- a/lib/PearlBee/Admin/Settings.pm
+++ b/lib/PearlBee/Admin/Settings.pm
@@ -51,7 +51,6 @@ post '/admin/settings/save' => sub {
 		$settings = resultset('Setting')->first;
 
 		$settings->update({
-			blog_path    => $path,
 			timezone     => $timezone,
 			social_media => ($social_media ? '1' : '0'),
 			multiuser    => ($multiuser ? '1' : '0'),

--- a/lib/PearlBee/Model/Schema/Result/Setting.pm
+++ b/lib/PearlBee/Model/Schema/Result/Setting.pm
@@ -35,13 +35,6 @@ __PACKAGE__->table("settings");
   default_value: 1
   is_nullable: 0
 
-=head2 blog_path
-
-  data_type: 'varchar'
-  default_value: '/'
-  is_nullable: 0
-  size: 255
-
 =head2 theme_folder
 
   data_type: 'varchar'
@@ -72,8 +65,6 @@ __PACKAGE__->add_columns(
   { data_type => "varchar", is_nullable => 0, size => 255 },
   "social_media",
   { data_type => "tinyint", default_value => 1, is_nullable => 0 },
-  "blog_path",
-  { data_type => "varchar", default_value => "/", is_nullable => 0, size => 255 },
   "theme_folder",
   { data_type => "varchar", is_nullable => 0, size => 255 },
   "blog_name",


### PR DESCRIPTION
The `blog_path` setting is not used anywhere in the application,
and therefore should be considered obsolete.

This fixes #51.