### PR TITLE
Add support for generating a static version of the blog via wallflower

### DIFF
--- a/environments/static.yml
+++ b/environments/static.yml
@@ -1,0 +1,6 @@
+# configuration file for static version of the web site
+
+# this will hide all "dynamic" pages
+# and produce links with the .html extension in all other pages
+
+static: 1

--- a/lib/PearlBee.pm
+++ b/lib/PearlBee.pm
@@ -38,6 +38,7 @@ hook 'before' => sub {
   session app_url   => config->{app_url} unless ( session('app_url') );
   session blog_name => resultset('Setting')->first->blog_name unless ( session('blog_name') );
   session multiuser => resultset('Setting')->first->multiuser;
+  if ( request->dispatch_path =~ /^(.*)\.html$/ ) { forward $1; }
 };
 
 =head

--- a/views/index.tt
+++ b/views/index.tt
@@ -4,17 +4,17 @@
       <div class="col-md-8">
         [% IF posts_for_user %]
           <div class="filtered_posts">
-            <h2> <i class="icon-user"></i> <a href="/posts/user/[% posts_for_user %]">[% posts_for_user %]</a></h2>
+            <h2> <i class="icon-user"></i> <a href="/posts/user/[% posts_for_user %][% settings.static && '.html' %]">[% posts_for_user %]</a></h2>
           </div>
         [% END %]
         [% IF posts_for_category %]
           <div class="filtered_posts">
-            <h2> <i class="icon-list"></i> <a href="/posts/category/[% posts_for_category %]">[% posts_for_category %]</a></h2>
+            <h2> <i class="icon-list"></i> <a href="/posts/category/[% posts_for_category %][% settings.static && '.html' %]">[% posts_for_category %]</a></h2>
           </div>
         [% END %]
         [% IF posts_for_tag %]
           <div class="filtered_posts">
-            <h2> <i class="icon-tag"></i> <a href="/posts/tag/[% posts_for_tag %]">[% posts_for_tag %]</a></h2>
+            <h2> <i class="icon-tag"></i> <a href="/posts/tag/[% posts_for_tag %][% settings.static && '.html' %]">[% posts_for_tag %]</a></h2>
           </div>
         [% END %]
          <div class="posts">
@@ -28,7 +28,7 @@
             [% END %]
             [% FOREACH post in posts %]
               <div class="entry">
-                 <h2><a href="/post/[% post.slug %]">[% post.title %]</a></h2>
+                 <h2><a href="/post/[% post.slug %][% settings.static && '.html' %]">[% post.title %]</a></h2>
                  
                  <!-- Meta details -->
                  <div class="meta">
@@ -36,18 +36,18 @@
                       <i class="icon-calendar"></i> [% post.created_date %]
                     </div>
                     <div class="block_elements">
-                      <i class="icon-user"></i> <a href="/posts/user/[% post.user.username %]">[% post.user.username %]</a>
+                      <i class="icon-user"></i> <a href="/posts/user/[% post.user.username %][% settings.static && '.html' %]">[% post.user.username %]</a>
                     </div>
                     
                     [% FOREACH category in post.post_categories %]
                       <div class="block_elements">
-                        <i class="icon-list"></i> <a href="[% session.app_url %]/posts/category/[% category.category.slug %]">[% category.category.name %]</a>
+                        <i class="icon-list"></i> <a href="[% session.app_url %]/posts/category/[% category.category.slug %][% settings.static && '.html' %]">[% category.category.name %]</a>
                       </div>
                     [% END %]
 
                     [% SET nr_of_comments = post.nr_of_comments %]
                     <div class="block_elements">
-                      <i class="icon-comment"></i> <a href="/post/[% post.slug %]#comments">[% nr_of_comments %] [% IF (nr_of_comments == 1) %] Comment [% ELSE %] Comments [% END %]</a></span>
+                      <i class="icon-comment"></i> <a href="/post/[% post.slug %][% settings.static && '.html' %]#comments">[% nr_of_comments %] [% IF (nr_of_comments == 1) %] Comment [% ELSE %] Comments [% END %]</a></span>
                     </div>
                  </div>
                  
@@ -64,7 +64,7 @@
                  </div>
                  
                  <!-- Read more -->
-                 <a href="[% session.app_url %]/post/[% post.slug %]" class="btn btn-info">Read More...</a>
+                 <a href="[% session.app_url %]/post/[% post.slug %][% settings.static && '.html' %]" class="btn btn-info">Read More...</a>
               </div>
             [% END %]
             [% IF posts.first %]

--- a/views/list_comments.tt
+++ b/views/list_comments.tt
@@ -15,7 +15,7 @@
                     </div>
                 [% ELSE %]
                     <div class="comment-author comment-author-registered">
-                        <i class="icon-user"></i> <a href="/posts/user/[% comment.uid.username %]" >[% comment.uid.username %]</a>
+                        <i class="icon-user"></i> <a href="/posts/user/[% comment.uid.username %][% settings.static && '.html' %]" >[% comment.uid.username %]</a>
                     </div>
                 [% END %]
                 
@@ -31,7 +31,9 @@
                 <!-- The Reply comment FORM -->
                 <a class="comment_reply" id="reply_comment_[% comment.id %]">Reply</a>
                 <div class='reply_comment_div' id="reply_comment_[% comment.id %]_div" div_set="[% fields.in_reply_to %]" field_fullname="[% fields.fullname %]" field_email="[% fields.email %]" field_website="[% fields.website %]" field_comment="[% fields.comment %]">
+                    [% IF ! settings.static %]
                     [% INCLUDE comment_form.tt %]
+                    [% END %]
                 </div>
                 
                 <!-- The Reply comments for this comment -->
@@ -48,7 +50,7 @@
                                 </div>
                             [% ELSE %]
                                 <div class="comment-author comment-author-registered">
-                                    <i class="icon-user"></i> <a href="/posts/user/[% reply.uid.username %]" >[% reply.uid.username %]</a>
+                                    <i class="icon-user"></i> <a href="/posts/user/[% reply.uid.username %][% settings.static && '.html' %]" >[% reply.uid.username %]</a>
                                 </div>
                             [% END %]
                             

--- a/views/post.tt
+++ b/views/post.tt
@@ -17,12 +17,12 @@
                                 <i class="icon-calendar"></i> [% post.created_date %]
                             </div>
                             <div class="block_elements">
-                                <i class="icon-user"></i> <a href="/posts/user/[% post.user.username %]">[% post.user.username %]</a>
+                                <i class="icon-user"></i> <a href="/posts/user/[% post.user.username %][% settings.static && '.html' %]">[% post.user.username %]</a>
                             </div>
 
                             [% FOREACH category in post.post_categories %]
                                 <div class="block_elements">
-                                    <i class="icon-list"></i> <a href="[% session.app_url %]/posts/category/[% category.category.slug %]">[% category.category.name %]</a>
+                                    <i class="icon-list"></i> <a href="[% session.app_url %]/posts/category/[% category.category.slug %][% settings.static && '.html' %]">[% category.category.name %]</a>
                                 </div>
                             [% END %]
 
@@ -47,7 +47,9 @@
                     </div>
                     
                     <!-- Comment posting -->
+                    [% IF ! settings.static %]
                     [% INCLUDE comment_form.tt %]
+                    [% END %]
                 
                     <!-- Comment section -->
                     [% INCLUDE list_comments.tt %]

--- a/views/post_sidebar.tt
+++ b/views/post_sidebar.tt
@@ -3,7 +3,7 @@
       <h4> Categories </h4>
       <ul class="simple-list">
       [% FOREACH category in categories %]
-        <li><a href="[% session.app_url %]/posts/category/[% category.slug %]"> [% category.name %] </a></li>
+        <li><a href="[% session.app_url %]/posts/category/[% category.slug %][% settings.static && '.html' %]"> [% category.name %] </a></li>
       [% END %]
       </ul>
     </div>
@@ -16,14 +16,14 @@
         <div class="tab-pane fade in active" id="recent">
           <ul class="simple-list">
             [% FOREACH recent_post in recent %]
-              <li><a href="[% session.app_url %]/post/[% recent_post.slug %]">[% recent_post.title %]</a></li>
+              <li><a href="[% session.app_url %]/post/[% recent_post.slug %][% settings.static && '.html' %]">[% recent_post.title %]</a></li>
             [% END %]
           </ul>
         </div>
         <div class="tab-pane fade" id="popular">
           <ul class="simple-list">
               [% FOREACH popular_post in popular %]
-                <li><a href="[% session.app_url %]/post/[% popular_post.slug %]">[% popular_post.title %]</a></li>
+                <li><a href="[% session.app_url %]/post/[% popular_post.slug %][% settings.static && '.html' %]">[% popular_post.title %]</a></li>
               [% END %]
            </ul>
         </div>
@@ -33,7 +33,7 @@
         <h4 class="widget-head">Tags</h4>
         <ul id="tag-list" class="cf">
           [% FOREACH tag in post.post_tags %]
-           <li><a class="btn btn-info" href="[% session.app_url %]/posts/tag/[% tag.tag.slug %]">[% tag.tag.name %]</a></li>
+           <li><a class="btn btn-info" href="[% session.app_url %]/posts/tag/[% tag.tag.slug %][% settings.static && '.html' %]">[% tag.tag.name %]</a></li>
           [% END %]
         </ul>
       </div>

--- a/views/sidebar.tt
+++ b/views/sidebar.tt
@@ -16,14 +16,14 @@
       <div class="tab-pane fade in active" id="recent">
         <ul class="simple-list">
           [% FOREACH post in recent %]
-            <li><a href="[% session.app_url %]/post/[% post.slug %]">[% post.title %]</a></li>
+            <li><a href="[% session.app_url %]/post/[% post.slug %][% settings.static && '.html' %]">[% post.title %]</a></li>
           [% END %] 
         </ul>
     </div>
     <div class="tab-pane fade" id="popular">
       <ul class="simple-list">
           [% FOREACH post in popular %]
-            <li><a href="[% session.app_url %]/post/[% post.slug %]">[% post.title %]</a></li>
+            <li><a href="[% session.app_url %]/post/[% post.slug %][% settings.static && '.html' %]">[% post.title %]</a></li>
           [% END %] 
        </ul>
     </div>
@@ -32,7 +32,7 @@
     <h4 class="widget-head">Tags</h4>
     <ul id="tag-list" class="cf">
       [% FOREACH tag in tags %]
-        <li><a href="[% session.app_url %]/posts/tag/[% tag.slug %]" class="btn btn-info">[% tag.name %]</a></li>
+        <li><a href="[% session.app_url %]/posts/tag/[% tag.slug %][% settings.static && '.html' %]me %]</a></li>
       [% END %]        
     </ul>
   </div>    

--- a/views/theme/header.tt
+++ b/views/theme/header.tt
@@ -39,12 +39,14 @@
                         <div class="navbar" role="banner">
                             <nav class="collapse navbar-collapse bs-navbar-collapse navbar-right" role="navigation">
                                 <ul class="nav navbar-nav">
+                        [% IF ! settings.static %]
                                     <li>
                                         <a href="[% session.app_url %]/sign-up"> Sign Up</a>
                                     </li>
                                     <li>
                                         <a href="[% session.app_url %]/admin"> Login</a>
                                     </li>
+                        [% END %]
                                 </ul>
                             </nav>
                         </div>


### PR DESCRIPTION
The goal is to be able to run the full version of the blog (with login, admin, post, etc. capabilities) on an internal site, and to publish the blog on a static Internet-facing web site. This way, it's possible to have the best of both worlds: a rich web application to manage the blog, and a safe, simple static web site to publish it.

This is done with a single extra setting: `static`. When set to a true value, the templates will hide all the "dynamic" elements of the application.

A lot of the templates have been modified to add the `.html` extensions with this piece of TT code: `[% settings.static && '.html' %]`. A cleaner approach, that would not require so much template changes, would be to give the various application objects one or more methods to return the URL. That way, the addition of the extension would be handled entirely in the code, and not in the templates. 